### PR TITLE
chore(ci): Fixed port number instance of variable.

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -25,7 +25,7 @@ jobs:
       mysql-service:
         image: mysql:8
         ports:
-          - ${{ env.DB_PORT }}:3306
+          - 3306:3306
         env:
           DB_USER: ${{ env.DB_USER }}
           DB_PASSWORD: ${{ env.DB_PASSWORD }}


### PR DESCRIPTION
Changed the mysql db variable to numbers since Github actions does not support mapping.
Below an explanation of what does not work yet. 
```
services:
    mysql-services:
        .
        .
        .
        ports:
          - ${{ env.db_var }}:3306
          - "${{ env.db_var }}:3306"
```
Instance it only allows:

```
services:
    mysql-services:
        .
        .
        .
        ports:
          - 3306:3306
```