### PR TITLE
test: added delay to print correctly the db connection status

### DIFF
--- a/devtools/testUtils/appInstanceResolver.js
+++ b/devtools/testUtils/appInstanceResolver.js
@@ -1,9 +1,12 @@
 let app = null
+const sleep = (ms) => new Promise(resolve => { setTimeout(resolve, ms) })
+
 const getApp = async () => {
   if (app) {
     return app
   }
   app = await require('../../index')
+  await sleep(1000)
   return app
 }
 


### PR DESCRIPTION
Added delay of 1000 ms to let the printing status of db appear first than the test information. 